### PR TITLE
fix: Correct typo in es2015 build

### DIFF
--- a/tsconfig.build.es2015.json
+++ b/tsconfig.build.es2015.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "target": "es2016",
     "module": "es2015",
-    "outDir": "dist/es2016"
+    "outDir": "dist/es2015"
   }
 }


### PR DESCRIPTION
The `outDir` in the `tsconfig.build.es2015.json` file was incorrectly set to `dist/es2016`, meaning that the reference to `dist/es2015` in `package.json` is incorrect and causes errors.

Addresses issue #12